### PR TITLE
Add cache-busting parameters to CSS URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <script type="text/javascript" src="js/jquery.dateFormat-1.0.js"></script>
     <script type="text/javascript" src="http://d3js.org/d3.v2.min.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="css/style.css">
-    <link rel="stylesheet" type="text/css" href="css/commits.css">
+    <link rel="stylesheet" type="text/css" href="css/style.css?v=201209070710">
+    <link rel="stylesheet" type="text/css" href="css/commits.css?v=201209070710">
 	<!--[if IE]>
 	<style>
 		.repo-item-cover, .repo-item-shadow, .repo-item-button


### PR DESCRIPTION
Instead of expecting each anonymous web visitor to clear their browser's history in order to avoid seeing the wrong layout after a CSS change, alter the CSS URLs by adding a version or timestamp parameter that we can change any time the CSS changes and we want to ensure that all visitors get the latest CSS file.
