### PR TITLE
Make project names more prominent

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@ body
 {
     font-family: sans-serif;
     font-size: 14px;
-    background-color: #E1E1E1;
+    background-color: #BABABA;
     margin: 0;
     padding: 10px;
     overflow: hidden;
@@ -128,7 +128,7 @@ body
 .repo-item-name
 {
     color: #B9090B;
-	background-color: #bbb;
+	background-color: #f2f2f2;
 	border-top: 1px;
 	border-right: 1px;
 	border-left: 1px;
@@ -136,9 +136,8 @@ body
 	border-color: black;
 	border-style: solid;
 	margin: 12px 20px 0 10px;
-	padding-bottom: 3px;
-    text-shadow: 2px 2px #aaa;
-	font-size: 18px;
+	padding: 3px 0;
+	font-size: 22px;
     font-weight: bold;
 	text-align: center;
 	text-transform: capitalize;

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <script type="text/javascript" src="js/jquery.dateFormat-1.0.js"></script>
     <script type="text/javascript" src="http://d3js.org/d3.v2.min.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="css/style.css?v=201209070710">
-    <link rel="stylesheet" type="text/css" href="css/commits.css?v=201209070710">
+    <link rel="stylesheet" type="text/css" href="css/style.css?v=201209121510">
+    <link rel="stylesheet" type="text/css" href="css/commits.css?v=201209121510">
 	<!--[if IE]>
 	<style>
 		.repo-item-cover, .repo-item-shadow, .repo-item-button


### PR DESCRIPTION
Make the page background darker grey in order to accomodate a much lighter grey background for the project title bars. Increase the size of the project name text and remove the fuzzy text shadow.
