### PR TITLE
Update index.html to fix "return false" error

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
 <div id="tab-content-repo">
 	<div id="repo-heading">
 	    <span><a href="https://github.com/netflix">Our Repositories</a></span>
-		<a href="javascript:repoView(true);"><img src="assets/glyphicons_156_show_thumbnails.png" width="22" height="22" alt="Thumbnails" border="0"></a>
-		<a href="javascript:repoView(false);"><img src="assets/glyphicons_114_list.png" width="22" height="22" alt="List" border="0"></a>
+		<a href="#" onclick="repoView(true);"><img src="assets/glyphicons_156_show_thumbnails.png" width="22" height="22" alt="Thumbnails" border="0"></a>
+		<a href="#" onclick="repoView(false);"><img src="assets/glyphicons_114_list.png" width="22" height="22" alt="List" border="0"></a>
 	</div>
 	<div id="repo-content">
 


### PR DESCRIPTION
Using the same "onclick" logic as the header links to prevent a return false error in FF.

Clicking on the repo tile icons should now filter appropriately.
