### PR TITLE
pass w3c markup validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" class="en">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"> 
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="shortcut icon" href="http://cdn-0.nflximg.com/en_US/icons/nficon.ico">
@@ -74,7 +75,7 @@
 
 <div id="tab-content-timeline">
     <div class="section-heading">Netflix OSS GitHub Repositories</div>
-    <div id="commits" orgName="Netflix" top-bottom-padding="380" left-right-padding="40" right-margin="50"></div>
+    <div id="commits" style="padding: 380px 40px; margin-right: 50px;"></div>
     <div class="help">Scroll to expand or compress the timelines, drag to shift the timelines earlier or later, and mouse over a timeline to see the committers's names and commit messages.</div>
     <script type="text/javascript" src="http://javaposseroundup.github.com/d3github/commitsbase.js"></script>
     <script type="text/javascript" src="js/commits.js?v=201303071100"></script>


### PR DESCRIPTION
Added one line (doctype) and changed two to pass for html 4.01 transitional.

before:
http://validator.w3.org/check?uri=http%3A%2F%2Fnetflix.github.io%2F%23repo&charset=%28detect+automatically%29&doctype=Inline&group=0

after:
http://validator.w3.org/check?uri=http%3A%2F%2Fmaxvgc.github.io%2Fnetflix.github.com%2F%23repo&charset=%28detect+automatically%29&doctype=Inline&group=0
