### PR TITLE
Relabel incorrect "Watchers" labels to "Stars"

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,8 @@
 		<div id="balloon-content">
 			<div id="balloon-description"></div>
 			<div class="baloon-field">
-				<span class="balloon-label">Watchers: </span>
+				<!-- GitHub JSON data only reports counts of Stars, not Watchers, although the JSON data mislabels the numbers as "watchers" -->
+				<span class="balloon-label">Stars: </span>
 				<span id="balloon-watchers"></span>
 			</div>
 			<div class="baloon-field">

--- a/js/nf.js
+++ b/js/nf.js
@@ -222,7 +222,8 @@ function buildRepoListContent()
         repoListContent += '<div class="repo-list-item-container" onClick="location.href=\'' + thisRepo.html_url + '\'; return false;">';
         repoListContent += '<div><a class="repo-list-item-anchor" href="' + thisRepo.html_url + '">' + thisRepo.name + '</a></div>';
         repoListContent += '<div class="repo-list-item-description">' + thisRepo.description + '</div>';
-        repoListContent += '<div><span class="repo-list-item-label">Watchers: </span><span class="repo-list-item-value">' + thisRepo.watchers + '</span></div>';
+        // GitHub JSON data only reports counts of Stars, not Watchers, although the JSON data mislabels the numbers as "watchers"
+        repoListContent += '<div><span class="repo-list-item-label">Stars: </span><span class="repo-list-item-value">' + thisRepo.watchers + '</span></div>';
         repoListContent += '<div><span class="repo-list-item-label">Forks: </span><span class="repo-list-item-value">' + thisRepo.forks + '</span></div>';
         repoListContent += '<div><span class="repo-list-item-label">Language: </span><span class="repo-list-item-value">' + thisRepo.language + '</span></div>';
         repoListContent += '<div><span class="repo-list-item-label">Open Issues: </span><span class="repo-list-item-value">' + thisRepo.open_issues + '</span></div>';


### PR DESCRIPTION
GitHub JSON data only reports counts of Stars, not Watchers, although the JSON data mislabels the numbers as "watchers"

@adrianco
