### PR TITLE
Fix carousel controlls focus

### DIFF
--- a/css/carousel.css
+++ b/css/carousel.css
@@ -6,7 +6,15 @@ body {
   color: #5a5a5a;
 }
 
+/* CUSTOMIZE THE CAROUSEL CONTROLLS
+-------------------------------------------------- */
+.carousel-control:focus {
+  opacity: .5;
+}
 
+.carousel-control:hover {
+  opacity: .9;
+}
 /* CUSTOMIZE THE NAVBAR
 -------------------------------------------------- */
 


### PR DESCRIPTION
Fixes #100 .

The issue was on this rules https://github.com/Netflix/netflix.github.com/blob/master/css/bootstrap.css#L6179-L6186

the same opacity was being assigned for both focus and hover
