### PR TITLE
Fix Copyright year in the footer of Homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@
           </div>
           <div class="powered-by-copyright col-md-4">
             <a href="/"><img src="images/Netflix-OSS-Logo-Small.png" /></a>
-            <p style="clear:both;">&copy; 2012-2016 NETFLIX, INC. ALL RIGHTS RESERVED</p>
+            <p style="clear:both;">&copy; 2012-2018 NETFLIX, INC. ALL RIGHTS RESERVED</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Update the copyright year in the footer from 2016 to current year i.e. 2018.