### PR TITLE
Dynamically update footer copyright date

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,11 +385,18 @@
           </div>
           <div class="powered-by-copyright col-md-4">
             <a href="/"><img src="images/Netflix-OSS-Logo-Small.png" /></a>
-            <p style="clear:both;">&copy; 2012-2016 NETFLIX, INC. ALL RIGHTS RESERVED</p>
+            <p style="clear:both;">&copy; 2012-<span id="date"></span> NETFLIX, INC. ALL RIGHTS RESERVED</p>
           </div>
         </div>
       </div>
     </footer>
+
+    <!-- Automatically update copyright date in footer 
+    ================================================== -->
+    <script>
+      let dateElement = document.getElementById("date");
+      dateElement.innerText = new Date().getFullYear();
+    </script>
 
     <!-- Bootstrap core JavaScript
     ================================================== -->


### PR DESCRIPTION
Fix for the following issue: [https://github.com/Netflix/netflix.github.com/issues/176](https://github.com/Netflix/netflix.github.com/issues/176)

- Wrote small JavaScript script to update the current year in the copyright located in the footer.