### PR TITLE
fix:100\next-prev-button

### DIFF
--- a/css/carousel.css
+++ b/css/carousel.css
@@ -137,3 +137,7 @@ body {
     margin-top: 120px;
   }
 }
+.carousel-control:focus {
+  outline: none; /* Removes the outline on focus */
+  background-color: transparent; /* Ensures no background remains */
+}

--- a/index.html
+++ b/index.html
@@ -398,5 +398,13 @@
     <script src="js/bootstrap.min.js"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="js/ie10-viewport-bug-workaround.js"></script>
+    <script>
+      document.querySelectorAll('.carousel-control').forEach(control => {
+  control.addEventListener('click', function () {
+    control.blur(); // Removes focus from the clicked element
+  });
+});
+
+    </script>
   </body>
 </html>


### PR DESCRIPTION
fix:100
Carousel 'next' and 'perv' buttons stay in 'hover' mode when clicked.
i have edited they js file to create a hover effect 
![image](https://github.com/user-attachments/assets/0c8b3c59-5616-4fa8-8664-ebf61d60f39b)
